### PR TITLE
Fix UB on right-shift.

### DIFF
--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -534,7 +534,7 @@ void execute(const Token *expr,
                 *result = result1 << result2;
             }
         } else if (expr->str() == ">>") {
-            if (result2 < 0) { // don't perform UB
+            if (result2 < 0 || result2 >= MathLib::bigint_bits) { // don't perform UB
                 *error=true;
             } else {
                 *result = result1 >> result2;

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -143,6 +143,9 @@ private:
             ASSERT_EQUALS("", errout.str());
         }
 
+        check("void f() { int x; x = 1 >> 64; }", &settings);
+        ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 32-bit value by 64 bits is undefined behaviour\n", errout.str());
+
         check("void foo() {\n"
               "  QList<int> someList;\n"
               "  someList << 300;\n"


### PR DESCRIPTION
The following input triggers an UBSan report because the undefined right-shift is actually performed:

`void f() { int x; r = 1 >> 64; }`

Copy the shift-width guard from the `<<` case over to `>>` to avoid this.